### PR TITLE
2016-09 big sync from bitbucket

### DIFF
--- a/manifests/allowed_command.pp
+++ b/manifests/allowed_command.pp
@@ -11,7 +11,7 @@ define sudoers::allowed_command(
   $comment          = undef,
   $allowed_env_variables = []
 ) {
-  require ::sudoers
+  include ::sudoers
 
   if ($user == undef and $group == undef) {
     fail('must define user or group')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,22 +1,38 @@
-# Class: sudoers
-class sudoers {
+#
+# = Class: sudoers
+#
+class sudoers (
+  $env_keep = [],
+){
+
   package { 'sudo':
     ensure => present,
   }
+
+  File {
+    owner => root,
+    group => root,
+  }
+
   file { '/etc/sudoers.d':
     ensure  => directory,
-    owner   => root,
-    group   => root,
     mode    => '0750',
     require => Package['sudo'],
   }
-  #exec {'add_sudo_include_d':
-  #  command => '/bin/echo "## Read drop-in files from /etc/sudoers.d (the # here does not mean a comment)" >> /etc/sudoers && /bin/echo "#includedir /etc/sudoers.d" >> /etc/sudoers',
-  #  unless  => '/bin/grep -q "^#includedir /etc/sudoers.d" /etc/sudoers',
-  #  require => File['/etc/sudoers.d'],
-  #}
+
   file_line { 'include_sudoersd':
     path => '/etc/sudoers',
     line => '#includedir /etc/sudoers.d',
   }
+
+  file { '/etc/sudoers.d/env_keep':
+    ensure  => file,
+    mode    => '0440',
+    content => template('sudoers/env_keep.erb'),
+  }
+
+  # autoload configs from zabbix::agent::configs from hiera
+  $sudoers_allowed_commands = hiera_hash('sudoers::allowed_commands', {})
+  create_resources(::sudoers::allowed_command, $sudoers_allowed_commands)
+
 }

--- a/templates/env_keep.erb
+++ b/templates/env_keep.erb
@@ -1,0 +1,3 @@
+<% @env_keep.each do |single_env_keep| -%>
+Defaults env_keep += "<%= single_env_keep %>"
+<% end -%>


### PR DESCRIPTION
- replace `require` with `include` to eliminate circular dependencies
- add `env_keep` param and matching template
- create resource from `sudoers::allowed_commands`
